### PR TITLE
Fix a jq incompatibility in the json-ordering test

### DIFF
--- a/testing/tests/json-ordering.zeek
+++ b/testing/tests/json-ordering.zeek
@@ -5,7 +5,7 @@
 # @TEST-REQUIRES: command -v jq
 # @TEST-EXEC: zeek -b %INPUT
 # @TEST-EXEC: jq '.[].name' zeek-logschema.json >logs
-# @TEST-EXEC: jq '.[] | select(.name=="test").fields.[].name' zeek-logschema.json >fields
+# @TEST-EXEC: jq '.[] | select(.name=="test").fields | .[].name' zeek-logschema.json >fields
 # @TEST-EXEC: btest-diff logs
 # @TEST-EXEC: btest-diff fields
 


### PR DESCRIPTION
I accidentally used a feature that only became available in 1.7, but 1.6 is still common in various distros.