### PR TITLE
JSON Schema: remove `is_optional` field from the Zeek annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,6 @@ $ cat zeek-conn-log.schema.json | jq
       "x-zeek": {
         "type": "time",
         "record_type": "Conn::Info",
-        "is_optional": false,
         "script": "base/protocols/conn/main.zeek"
       }
     },

--- a/scripts/export/jsonschema.zeek
+++ b/scripts/export/jsonschema.zeek
@@ -12,9 +12,6 @@ export {
 		_type: string;
 		## Record type containing this field (e.g. "Conn::Info", "conn_id").
 		record_type: string;
-		## Whether the field is optional. This is itself optional since
-		## it's not available before Zeek 6.
-		is_optional: bool &optional;
 		## Script that defines the field, relative to the scripts folder
 		## (e.g. "base/init-bare.zeek"). This is optional because it's
 		## not available before Zeek 6.0.
@@ -284,8 +281,6 @@ function process_log(ex: Log::Schema::Exporter, log: Log::Schema::Log)
 			{
 			local annos = ZeekAnnotations($_type=field$_type, $record_type=field$record_type);
 
-			if ( field?$is_optional )
-				annos$is_optional = field$is_optional;
 			if ( field?$script )
 				annos$script = field$script;
 			if ( field?$package )

--- a/testing/Baseline/tests.jsonschema-defaults/zeek-test-log.schema.json
+++ b/testing/Baseline/tests.jsonschema-defaults/zeek-test-log.schema.json
@@ -15,7 +15,6 @@
       "x-zeek": {
         "type": "addr",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -25,7 +24,6 @@
       "x-zeek": {
         "type": "bool",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -36,7 +34,6 @@
       "x-zeek": {
         "type": "count",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -46,7 +43,6 @@
       "x-zeek": {
         "type": "double",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -61,7 +57,6 @@
       "x-zeek": {
         "type": "enum transport_proto",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -71,7 +66,6 @@
       "x-zeek": {
         "type": "int",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -81,7 +75,6 @@
       "x-zeek": {
         "type": "interval",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -93,7 +86,6 @@
       "x-zeek": {
         "type": "port",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -107,7 +99,6 @@
       "x-zeek": {
         "type": "addr",
         "record_type": "conn_id",
-        "is_optional": false,
         "script": "base/init-bare.zeek"
       }
     },
@@ -119,7 +110,6 @@
       "x-zeek": {
         "type": "port",
         "record_type": "conn_id",
-        "is_optional": false,
         "script": "base/init-bare.zeek"
       }
     },
@@ -133,7 +123,6 @@
       "x-zeek": {
         "type": "addr",
         "record_type": "conn_id",
-        "is_optional": false,
         "script": "base/init-bare.zeek"
       }
     },
@@ -145,7 +134,6 @@
       "x-zeek": {
         "type": "port",
         "record_type": "conn_id",
-        "is_optional": false,
         "script": "base/init-bare.zeek"
       }
     },
@@ -159,7 +147,6 @@
       "x-zeek": {
         "type": "set[count]",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -169,7 +156,6 @@
       "x-zeek": {
         "type": "string",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -183,7 +169,6 @@
       "x-zeek": {
         "type": "subnet",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -196,7 +181,6 @@
       "x-zeek": {
         "type": "time",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -210,7 +194,6 @@
       "x-zeek": {
         "type": "vector of count",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -221,7 +204,6 @@
       "x-zeek": {
         "type": "string",
         "record_type": "Testlog::Info",
-        "is_optional": true,
         "script": "testlog.zeek"
       }
     },
@@ -231,7 +213,6 @@
       "x-zeek": {
         "type": "string",
         "record_type": "Testlog::Info",
-        "is_optional": true,
         "script": "testlog.zeek"
       }
     },
@@ -240,7 +221,6 @@
       "x-zeek": {
         "type": "string",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     }

--- a/testing/Baseline/tests.jsonschema-stdout/stdout
+++ b/testing/Baseline/tests.jsonschema-stdout/stdout
@@ -15,7 +15,6 @@
       "x-zeek": {
         "type": "addr",
         "record_type": "Second::Info",
-        "is_optional": false,
         "script": "secondlog.zeek"
       }
     }
@@ -40,7 +39,6 @@
       "x-zeek": {
         "type": "addr",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -50,7 +48,6 @@
       "x-zeek": {
         "type": "bool",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -61,7 +58,6 @@
       "x-zeek": {
         "type": "count",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -71,7 +67,6 @@
       "x-zeek": {
         "type": "double",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -86,7 +81,6 @@
       "x-zeek": {
         "type": "enum transport_proto",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -96,7 +90,6 @@
       "x-zeek": {
         "type": "int",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -106,7 +99,6 @@
       "x-zeek": {
         "type": "interval",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -118,7 +110,6 @@
       "x-zeek": {
         "type": "port",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -132,7 +123,6 @@
       "x-zeek": {
         "type": "addr",
         "record_type": "conn_id",
-        "is_optional": false,
         "script": "base/init-bare.zeek"
       }
     },
@@ -144,7 +134,6 @@
       "x-zeek": {
         "type": "port",
         "record_type": "conn_id",
-        "is_optional": false,
         "script": "base/init-bare.zeek"
       }
     },
@@ -158,7 +147,6 @@
       "x-zeek": {
         "type": "addr",
         "record_type": "conn_id",
-        "is_optional": false,
         "script": "base/init-bare.zeek"
       }
     },
@@ -170,7 +158,6 @@
       "x-zeek": {
         "type": "port",
         "record_type": "conn_id",
-        "is_optional": false,
         "script": "base/init-bare.zeek"
       }
     },
@@ -184,7 +171,6 @@
       "x-zeek": {
         "type": "set[count]",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -194,7 +180,6 @@
       "x-zeek": {
         "type": "string",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -208,7 +193,6 @@
       "x-zeek": {
         "type": "subnet",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -221,7 +205,6 @@
       "x-zeek": {
         "type": "time",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -235,7 +218,6 @@
       "x-zeek": {
         "type": "vector of count",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     },
@@ -246,7 +228,6 @@
       "x-zeek": {
         "type": "string",
         "record_type": "Testlog::Info",
-        "is_optional": true,
         "script": "testlog.zeek"
       }
     },
@@ -256,7 +237,6 @@
       "x-zeek": {
         "type": "string",
         "record_type": "Testlog::Info",
-        "is_optional": true,
         "script": "testlog.zeek"
       }
     },
@@ -265,7 +245,6 @@
       "x-zeek": {
         "type": "string",
         "record_type": "Testlog::Info",
-        "is_optional": false,
         "script": "testlog.zeek"
       }
     }


### PR DESCRIPTION
This was redundant since JSON Schema already provides native support for indicating optionality via the `required` keyword.