### PR TITLE
Add `Log::Schema::show_defaults` toggle to tame difficult defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,8 +466,12 @@ A few Zeek logs use `&default` attributes for which this package produces
 different output from run to run in schema formats that capture default values,
 such as CSV. Specifically, the SMB logs have timestamps defaulting to current
 network time, producing different timestamps every time you generate the schema.
-You can adjust this and other troublesome output via the `Log::Schema::adapt()`
-hook mentioned above:
+
+The `Log::Schema::show_defaults` toggle, `T` by default, lets you suppress
+defaults in generated schemas when you set it to `F`. This is the easiest way to
+tame such fields, but affects all of them. You can also operate more surgically,
+adjusting this and other troublesome output via the `Log::Schema::adapt()` hook
+mentioned above:
 
 ```zeek
 hook Log::Schema::adapt(logs: Log::Schema::LogsTable) {

--- a/scripts/main.zeek
+++ b/scripts/main.zeek
@@ -18,7 +18,8 @@ export {
 		## Whether the field is optional. This is itself optional since
 		## it's not available before Zeek 6.
 		is_optional: bool &optional;
-		## Default value of the field, if defined.
+		## Default value of the field, if defined, and defaults aren't
+		## disabled via the show_defaults toggle.
 		_default: any &optional;
 		## If available, the docstring for the field.
 		docstring: string &optional;
@@ -137,6 +138,13 @@ export {
 	## Whether to export automatically at startup. Set this to false and
 	## invoke run_export() at a time of your choosing for custom usage.
 	const run_at_startup = T &redef;
+
+	## Whether to include field &default values in schema information. This
+	## is on by default, but since defaults at times get in the way (for
+	## example when a default value changes with every Zeek invocation and
+	## you'd like to diff schemas), setting this to F causes the package to
+	## omit the values.
+	const show_defaults = T &redef;
 
 	## The log filter to use for determining Zeek's logs, including
 	## included/excluded fields, log extensions, and field name mappings.
@@ -264,7 +272,7 @@ function unfold_field(rtype: string, fieldname: string, fieldinfo: record_field,
 		    $_type = fieldinfo$type_name,
 		    $record_type = rtype);
 
-		if ( fieldinfo?$default_val )
+		if ( show_defaults && fieldinfo?$default_val )
 			field$_default = fieldinfo$default_val;
 
 		local docstring = get_record_field_comments(qualified_fieldname);

--- a/testing/Baseline/tests.jsonschema-defaults-nofrills/zeek-test-log.schema.json
+++ b/testing/Baseline/tests.jsonschema-defaults-nofrills/zeek-test-log.schema.json
@@ -86,8 +86,7 @@
     },
     "sd": {
       "description": "A default value.",
-      "type": "string",
-      "default": "yes"
+      "type": "string"
     },
     "so": {
       "description": "An optional value.",

--- a/testing/tests/jsonschema-defaults-nofrills.zeek
+++ b/testing/tests/jsonschema-defaults-nofrills.zeek
@@ -11,3 +11,5 @@
 redef Log::Schema::JSONSchema::add_zeek_annotations = F;
 redef Log::Schema::JSONSchema::add_detailed_constraints = F;
 redef Log::Schema::JSONSchema::add_examples = F;
+
+redef Log::Schema::show_defaults = F;


### PR DESCRIPTION
When switched to `F`, the package omits default values from generated schemas. This helps in cases where defaults get in the way, such as when diffing schemas and defaults change with every Zeek invocation.