### PR TITLE
Bugfix: multi-schema export to a single file was missing newlines

### DIFF
--- a/scripts/export/json.zeek
+++ b/scripts/export/json.zeek
@@ -55,12 +55,12 @@ function write_all_schemas(hdl: file, ex: Log::Schema::Exporter, logs: Log::Sche
 		exps += log$json_export;
 		}
 
-	write_file(hdl, to_json(exps));
+	write_file(hdl, to_json(exps) + "\n");
 	}
 
 function write_single_schema(hdl: file, ex: Log::Schema::Exporter, log: Log::Schema::Log)
 	{
-	write_file(hdl, to_json(log$json_export));
+	write_file(hdl, to_json(log$json_export) + "\n");
 	}
 
 event zeek_init()

--- a/scripts/export/jsonschema.zeek
+++ b/scripts/export/jsonschema.zeek
@@ -302,13 +302,13 @@ function write_all_schemas(hdl: file, ex: Log::Schema::Exporter, logs: Log::Sche
 	{
 	for ( _, log in logs )
 		{
-		write_file(hdl, to_json(log$jsonschema_export$schema));
+		write_file(hdl, to_json(log$jsonschema_export$schema) + "\n");
 		}
 	}
 
 function write_single_schema(hdl: file, ex: Log::Schema::Exporter, log: Log::Schema::Log)
 	{
-	write_file(hdl, to_json(log$jsonschema_export$schema));
+	write_file(hdl, to_json(log$jsonschema_export$schema) + "\n");
 	}
 
 event zeek_init()

--- a/testing/tests/jsonschema-stdout.zeek
+++ b/testing/tests/jsonschema-stdout.zeek
@@ -2,6 +2,10 @@
 #
 # @TEST-REQUIRES: command -v jq
 # @TEST-EXEC: zeek -b %INPUT >stdout 2>stderr
+#
+# The output should have two lines, one for each log.
+# @TEST-EXEC: test $(cat stdout | wc -l) -eq 2
+#
 # @TEST-EXEC: TEST_DIFF_CANONIFIER=$SCRIPTS/diff-prettify-json btest-diff stdout
 # @TEST-EXEC: btest-diff stderr
 


### PR DESCRIPTION
In contrast to what's claimed in the docs, such exports did not in fact separate every log's schema onto a separate line, JSONL-style. This could confuse some JSON processors.

For consistency this includes newlines in any JSON outputs, not just multi-schema JSON Schema files.