### PR TITLE
Remove summary from zkg.meta

### DIFF
--- a/zkg.meta
+++ b/zkg.meta
@@ -1,7 +1,6 @@
 [package]
 script_dir = scripts
 test_command = cd testing && ./btest.sh
-summary = Log data schema generation
 description = This package generates schemas for Zeek's logs.
     For every log your Zeek installation produces, the schema describes each log
     field including name, type, docstring, and more. The package supports JSON Schema,


### PR DESCRIPTION
Based on the [zkg docs](https://docs.zeek.org/projects/package-manager/en/stable/package.html#package-metadata) `summary` doesn't seem to be a supported field.